### PR TITLE
News are now displayed in two columns on all other pages than the frontpage

### DIFF
--- a/studlan/themes/bootstrap202/templates/news/news.html
+++ b/studlan/themes/bootstrap202/templates/news/news.html
@@ -18,7 +18,7 @@ studLAN - News
     <div class="row"><div class="span9"><h1>News</h1></div></div>
 
     {% for article in articles.object_list %}
-        {% if forloop.counter < 3 %}
+        {% if forloop.counter < 3 and page == 1 %}
             <div class="row">
                 <div class="span9">
                     <h2>{{ article.title }}</h2>


### PR DESCRIPTION
This should fix issue #39.
