### PR TITLE
Allow support email to be set in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 #
 
 local.py
-
+dev.db
 
 
 # Created by https://www.gitignore.io/api/vim,linux,windows,osx,intellij,pycharm,python

--- a/apps/misc/templatetags/settings.py
+++ b/apps/misc/templatetags/settings.py
@@ -10,3 +10,7 @@ def site_name():
 @register.simple_tag
 def stripe_public_key():
     return getattr(settings, "STRIPE_PUBLIC_KEY", "")
+
+@register.simple_tag
+def support_mail():
+    return getattr(settings, "SUPPORT_MAIL", "")

--- a/studlan/settings/base.py
+++ b/studlan/settings/base.py
@@ -191,6 +191,8 @@ LOGGING = {
     }
 }
 
+SUPPORT_MAIL = ''
+
 #Overiding messagetags to match bootstrap 3
 MESSAGE_TAGS = {message_constants.ERROR: 'danger'}
 

--- a/studlan/settings/example-local.py
+++ b/studlan/settings/example-local.py
@@ -13,18 +13,19 @@ DATABASES = {
 }
 
 STUDLAN_FROM_MAIL = 'studlan@online.ntnu.no'
+SUPPORT_MAIL = 'change@me.com'
 
 #EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'  # real
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  # prints
 
-SITE_NAME = "studLAN"
+SITE_NAME = 'studLAN'
 
 #Enable and set to your domain when deployed
 #CSRF_COOKIE_DOMAIN = 'studlan.no'
 CSRF_COOKIE_HTTPONLY = True
 
-STRIPE_PUBLIC_KEY = "pk_test_6pRNASCoBOKtIshFeQd4XMUh"
+STRIPE_PUBLIC_KEY = 'pk_test_6pRNASCoBOKtIshFeQd4XMUh'
 
-STRIPE_PRIVATE_KEY = "sk_test_BQokikJOvBiI2HlWgH4olfQ2"
+STRIPE_PRIVATE_KEY = 'sk_test_BQokikJOvBiI2HlWgH4olfQ2'
 
-GOOGLE_API_KEY = "APIKEYHERE"
+GOOGLE_API_KEY = 'APIKEYHERE'

--- a/studlan/settings/example-prod-local.py
+++ b/studlan/settings/example-prod-local.py
@@ -16,6 +16,7 @@ DATABASES = {
 }
 
 STUDLAN_FROM_MAIL = 'noreply@domain.no'
+SUPPORT_MAIL = 'change@me.com'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'  # real
 EMAIL_HOST = "smtp.domain.no"

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title> 
-            {% site_name %} - 
+        <title>
+            {% site_name %} -
             {% block title %}
             {% endblock title %}
         </title>
@@ -18,7 +18,7 @@
         <script src="{{ STATIC_URL }}js/bootstrap.min.js" type="text/javascript"></script>
         <script src="{{ STATIC_URL }}js/custom.js" type="text/javascript"></script>
     </head>
-    
+
     <body>
         <div class="navbar navbar-fixed-top navbar-default" role="navigation">
             <div class="container">
@@ -42,7 +42,7 @@
                     {% include "navigation.html" %}
                     <!-- Language selection -->
                     <ul class="nav navbar-nav navbar-right language-dropdown">
-                        <li role="presentation" class="dropdown"> 
+                        <li role="presentation" class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
                                 {% trans "Language" %} <b class="caret"></b>
                             </a>
@@ -50,7 +50,7 @@
                             {% for lang in LANGUAGES %}
                                 <li>
                                     <form class="language-list" name="setLang{{lang.1}}" action="/misc/change_language" method="POST">{% csrf_token %}
-                                        <input type="hidden" name="language" value="{{ lang.0 }}"/> 
+                                        <input type="hidden" name="language" value="{{ lang.0 }}"/>
                                     </form>
                                     <a href="#" onclick="document.setLang{{ lang.1 }}.submit();return false;">{{ lang.1 }}</a>
                                 </li>
@@ -71,7 +71,7 @@
                 <div class="row breadcrumbs">
                     <div class="col-md-9">
                         <ul class="breadcrumb">
-                            {% for text, link in breadcrumbs %} 
+                            {% for text, link in breadcrumbs %}
                                 {% if not forloop.last %}
                                     <li>
                                         <a href="{{ link }}">{{ text }}</a>
@@ -89,7 +89,7 @@
                 {% for message in messages %}
                     <div class="row">
                         <div class="col-md-9">
-                            <div class="flash fade in alert alert-dismissible alert-{{ message.tags }}"> 
+                            <div class="flash fade in alert alert-dismissible alert-{{ message.tags }}">
                                 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                                 <p>{{ message }}</p>
                             </div>
@@ -104,7 +104,7 @@
                 <div class="col-md-9">
                     <footer>
                         <hr />
-                        <p><a href="https://github.com/casualgaming/studlan">https://github.com/CasualGaming/studlan</a> - <a href="mailto:support@casualgaming.no?Subject=studlan.no" target="_top">Support</a></p>
+                        <p><a href="https://github.com/casualgaming/studlan">https://github.com/CasualGaming/studlan</a> - <a href="mailto:{% support_mail %}?Subject=Support: {% site_name %}" target="_top">Support</a></p>
                     </footer>
                 </div>
             </div>


### PR DESCRIPTION
### Status

- [x] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description
Adds settings parameter SUPPORT_MAIL which is used through a template tag for the footer on the frontpage.

### Checklist

- [x] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [x] I have introduced changes to build configuration.
