### PR TITLE
Optimize Docker image size even more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV LIBRARY_PATH=/lib:/usr/lib
 ENV DIR=/srv/app
 
 RUN apk update && \
-    apk add postgresql-dev \
+    apk add --no-cache postgresql-dev \
         mailcap \
         build-base \
         python-dev \
@@ -23,7 +23,7 @@ WORKDIR $DIR
 
 # Install requirements
 COPY ./requirements $DIR/requirements
-RUN pip install -r requirements/production.txt --upgrade
+RUN pip install --no-cache-dir -r requirements/production.txt --upgrade
 
 # Delete unneeded files.
 RUN apk del build-base \


### PR DESCRIPTION
### Status
- [x] Done
### Description

Tell apk and pip to not cache dowloads, which saves ~25 MB in the final image.
### Minor Changes
- Optimize Docker image to be even smaller in size.
### Other

```
IMAGE ID            SIZE
e65dde5baa5b        295.6 MB
bcf49c4ef8cf        318.6 MB
```

bcf49c4ef8cf is image built from Dockerfile in current master
e65dde5baa5b is image built from Dockerfile after this PR
