### PR TITLE
Add automatic correlation between layout and seating capacity

### DIFF
--- a/apps/seating/migrations/0006_auto_20160429_2028.py
+++ b/apps/seating/migrations/0006_auto_20160429_2028.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seating', '0005_auto_20150609_2309'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='seating',
+            name='number_of_seats',
+            field=models.IntegerField(default=0, help_text=b'This field is automatically updated to match the chosen layout. Change the chosen layout to alter this field', verbose_name=b'number of seats'),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
### Status

- [x] Done
- [ ] Work in progress
- [x] Needs testing from others

### Description
This forces seatings to use the same number of seats as the layout it is utilizing. This is to avoid misconfigurations and errors. 

### Checklist

- [ ] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [ ] I have introduced changes to build configuration.