### PR TITLE
Makes seating work on mobile fixes 107

### DIFF
--- a/files/css/custom.css
+++ b/files/css/custom.css
@@ -221,12 +221,40 @@ div#btn-profile {
     padding: 1px;
 }
 
+.svg-container {
+      position: relative;
+}
 
+.stretcher-bar {
+  width: 100%;
+  height: 75vh;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.content-svg {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  max-width: 100%;
+  max-height: 100%;
+}
 
 @media (max-width:1114px) {
-    
+
     .sidebar-wrapper{
-        display: none;
+        position: relative;
+        width: 100%;
+        max-height: 30%;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        max-width: 100%;
     }
 
     .language-dropdown {

--- a/files/js/seating.js
+++ b/files/js/seating.js
@@ -18,15 +18,21 @@ $(document).ready(function(){
         },
       };
     });
-    $(".svg-container > svg").attr("class", "content-svg");
-    var main_svg = $(".content-svg");
-    var w = main_svg.attr('width').replace('px', '');
-    var h = main_svg.attr('height').replace('px', '');
+
+    var main_svg = $("#svg-wrapper > svg");
+    var h = "60vh";
+    if (main_svg.attr("viewBox") !== undefined || main_svg.attr("viewBox") !== false){
+        main_svg.attr({
+            viewBox: [0,0, main_svg.attr('width').replace('px', ''),main_svg.attr('height').replace('px', '')].join(' ')
+        });
+    }
 
     main_svg.attr({
-        viewBox: [-25, 0, w, h].join(" "),
+        height: h,
         preserveAspectRatio: "xMidYMid meet"
     });
+
+    main_svg.removeAttr("width");
 
     var selectedSeat;
     var selectedSeatClass;

--- a/files/js/seating.js
+++ b/files/js/seating.js
@@ -1,7 +1,38 @@
 $(document).ready(function(){
 
+
+    ['preserveAspectRatio', 'viewBox'].forEach(function(k) {
+      // jQuery converts the attribute name to lowercase before
+      // looking for the hook.
+      $.attrHooks[k.toLowerCase()] = {
+        set: function(el, value) {
+          if (value) {
+            el.setAttribute(k, value);
+          } else {
+            el.removeAttribute(k, value);
+          }
+          return true;
+        },
+        get: function(el) {
+          return el.getAttribute(k);
+        },
+      };
+    });
+    $(".svg-container > svg").attr("class", "content-svg");
+    var main_svg = $(".content-svg");
+    var w = main_svg.attr('width').replace('px', '');
+    var h = main_svg.attr('height').replace('px', '');
+
+    main_svg.attr({
+        viewBox: [-25, 0, w, h].join(" "),
+        preserveAspectRatio: "xMidYMid meet"
+    });
+
     var selectedSeat;
     var selectedSeatClass;
+
+
+
 
     $('rect').click( function(e) {
         e.preventDefault();
@@ -62,4 +93,10 @@ $(document).ready(function(){
         }
 
     });
+
+});
+$(window).resize(function() {
+
+
+
 });

--- a/templates/seating/seating.html
+++ b/templates/seating/seating.html
@@ -30,8 +30,9 @@ Seating
 
         <div class="row">
             <div class="col-md-9 svg-container">
-                <img src="data:image/svg+xml,%3Csvg viewBox='0 0 4 3' xmlns='http://www.w3.org/2000/svg'/%3E" alt="" class="stretcher-bar">
-                {{ template|safe }}
+                <div id="svg-wrapper">
+                    {{ template|safe }}
+                </div>
             </div>
             <div class="col-md-3 col-sm-12 col-xs-12">
                 <div class="sidebar-wrapper seat-wrapper">

--- a/templates/seating/seating.html
+++ b/templates/seating/seating.html
@@ -3,9 +3,10 @@
 Seating
 {% endblock title %}
 {% load i18n %}
+{% load static %}
 
 {% block content %}
-    <script type="text/javascript" src="{{ STATIC_URL }}js/seating.js"></script>
+    <script type="text/javascript" src="{% static 'js/seating.js' %}"></script>
     <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
     {% if seatings %}
         <div class="row">
@@ -28,10 +29,11 @@ Seating
         {% endif %}
 
         <div class="row">
-            <div class="col-md-9">
+            <div class="col-md-9 svg-container">
+                <img src="data:image/svg+xml,%3Csvg viewBox='0 0 4 3' xmlns='http://www.w3.org/2000/svg'/%3E" alt="" class="stretcher-bar">
                 {{ template|safe }}
             </div>
-            <div class="col-md-3">
+            <div class="col-md-3 col-sm-12 col-xs-12">
                 <div class="sidebar-wrapper seat-wrapper">
                 	<div class="well sidebar">
                         <ul class="nav nav-stacked">


### PR DESCRIPTION
### Status

- [ ] Done
- [ ] Work in progress
- [x] Needs testing from others

### Description
Along with chages to how the svg is displayed by changing layout values to this it works on mobile units, not perfectly since svg is a retard, we have to make sacrifices.

`<svg class="content-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="15 20 700 900" preserveAspectRatio="xMidYMid" zoomAndPan="disable"><rect id="svgEditorBackground" x="0" y="0" width="1590" height="930" style="stroke: none; fill: none;"/>
`
### Checklist

- [x] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [ ] I have introduced changes to build configuration.


### Minor Changes
- Need updating in exsisting Layout 
