### PR TITLE
Add admin actions to activate, deactivate and logout users

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This approach is faster than running with Docker, plus it has colors. It will cr
 This approach takes more time to build, but is more similar to production. It places a settings file, the SQLite database file and the logs under `/tmp/studlan`.
 * Build and run: `manage/run-docker-dev.sh`
 
-If Docker starts to fill up your hard drive, run `docker system prune -a` to delete all local Docker data.
+If Docker starts to fill up your hard drive, run `docker system prune -a` to delete all local Docker stopped containers, unused networks, unused images and build cache.
 
 # Testing and Validating
 * Setup: `manage/setup-test.sh` (first time or after project change)

--- a/apps/authentication/forms.py
+++ b/apps/authentication/forms.py
@@ -33,9 +33,7 @@ class LoginForm(forms.Form):
             else:
                 self.add_error('username', _(u'Your account is inactive, try to recover it.'))
         else:
-            self.add_error('password', _(u'Login failed!'
-                                         u' Either the account does not exist, is inactive, or the username–password combination is incorrect.'
-                                         u' If you believe the account exists or you have forgotten the username or password, try the password recovery feature.'))
+            self.add_error('password', _(u'Login failed! Either the account does not exist, is inactive, or the username–password combination is incorrect.'))
         return self.cleaned_data
 
     def login(self, request):

--- a/apps/userprofile/admin.py
+++ b/apps/userprofile/admin.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin
+from django.contrib import messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.contrib.sessions.models import Session
 from django.forms import models
 
 from apps.userprofile.models import Alias, AliasType, UserProfile
@@ -27,9 +29,31 @@ class UserProfileInline(admin.StackedInline):
 
 class UserProfileAdmin(UserAdmin):
     inlines = (UserProfileInline,)
-    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff')
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'is_active', 'date_joined', 'last_login')
     list_filter = ('groups', 'is_staff', 'is_superuser')
     filter_horizontal = ('groups',)
+    actions = ['activate_users', 'deactivate_users', 'forcefully_logout_users']
+
+    def activate_users(self, request, queryset):
+        queryset.update(is_active=True)
+
+    def deactivate_users(self, request, queryset):
+        for user in queryset:
+            if user.id == request.user.id:
+                self.message_user(request, 'You cannot deactivate yourself! No actions were performed.', level=messages.WARNING)
+                return
+        queryset.update(is_active=False)
+
+    def forcefully_logout_users(self, request, queryset):
+        for session in Session.objects.all():
+            session_user = int(session.get_decoded().get('_auth_user_id'))
+            for user in queryset:
+                if user.id == session_user:
+                    session.delete()
+
+    activate_users.short_description = 'Activate'
+    deactivate_users.short_description = 'Deactivate'
+    forcefully_logout_users.short_description = 'Forcefully logout'
 
 
 admin.site.register(User, UserProfileAdmin)

--- a/manage/run-all-checks.sh
+++ b/manage/run-all-checks.sh
@@ -36,3 +36,6 @@ $MANAGE test --no-input
 # Run flake8 static code analysis
 # Uses settings from .flake8
 flake8
+
+echo
+echo "Success!"

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -23,7 +23,7 @@ Login
                 {% endfor %}
                 <div class="form-actions login-buttons">
                     <input type="submit" class="btn btn-primary" value="{% trans "Login" %}" /> 
-                    <a href="{% url 'auth_recover' %}" class="btn btn-info">{% trans "Recover password" %}</a>
+                    <a href="{% url 'auth_recover' %}" class="btn btn-info">{% trans "Recover username and password" %}</a>
                 </div>
             </fieldset>
             <input type="hidden" name="next" value="{% if next %}{{ next }}{% endif %}"/>


### PR DESCRIPTION
### Status

- [X] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description
Implements #204. This adds admin actions for activating, deleting and forcefully logging out multiple selected users in the admin panel.

### Checklist

- [X] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [ ] I have introduced changes to build configuration.

### Minor Changes
- Add admin action to enable or disable selected users.
- Add admin action to forcefully log out selected users.

### Other
The users can activate themselves by recovering their account by email, as intended.