### PR TITLE
Hide full user names where they aren't needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+
+### Changed
+- Hide the full names of users where they aren't needed.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+- Fix broken auth for the downloadable PDF files for the seating.
+- Replace the drop-down list with all usernames in the team invite section with a text field.
+
+
 ## [1.4.0] - 2019-03-10
 ### Added
 - Added changelog file.

--- a/apps/competition/models.py
+++ b/apps/competition/models.py
@@ -163,7 +163,7 @@ class Participant(models.Model):
 
     def __unicode__(self):
         if self.user:
-            return self.user.get_full_name()
+            return self.user.username
         else:
             return unicode(self.team)
 

--- a/apps/lan/models.py
+++ b/apps/lan/models.py
@@ -69,7 +69,7 @@ class Attendee(models.Model):
     arrived = models.BooleanField('has arrived', default=False)
 
     def __unicode__(self):
-        return self.user.get_full_name() + ' - ' + self.lan.title
+        return self.user.username + ' – ' + self.lan.title
 
     class Meta:
         ordering = ['-user', 'lan']
@@ -116,7 +116,7 @@ class Ticket(models.Model):
     invalid_description = models.TextField(null=True, blank=True)
 
     def __unicode__(self):
-        return self.user.username + '(' + self.user.get_full_name() + ')'
+        return self.user.username
 
     class Meta:
         index_together = ['user', 'ticket_type']

--- a/apps/seating/views.py
+++ b/apps/seating/views.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from bs4 import BeautifulSoup
 
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse

--- a/apps/seating/views.py
+++ b/apps/seating/views.py
@@ -88,11 +88,11 @@ def seating_details(request, lan_id, seating_id=None, seat_id=None):
             else:
                 children[0]['class'] = ' seating-node-occupied'
                 children[0]['status'] = 'occupied'
-                children[0]['seat-user'] = unicode(seats[counter].user.get_full_name())
+                children[0]['seat-user'] = unicode(seats[counter].user.username)
 
                 # Separate title element for chrome support
                 title = dom.new_tag('title')
-                title.string = unicode(seats[counter].user.get_full_name())
+                title.string = unicode(seats[counter].user.username)
                 tag.append(title)
 
         counter += 1

--- a/apps/seating/views.py
+++ b/apps/seating/views.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
@@ -169,6 +170,7 @@ def leave(request, seating_id, seat_id):
     return redirect(seating)
 
 
+@staff_member_required
 def seating_list(request, seating_id):
     seating = get_object_or_404(Seating, pk=seating_id)
     lan = get_object_or_404(LAN, id=seating.lan.id)
@@ -207,6 +209,7 @@ def leave2(request, lan_id, seating_id, seat_id):
     return leave(request, seating_id, seat_id)
 
 
+@staff_member_required
 def seating_map(request, seating_id):
     seating = get_object_or_404(Seating, pk=seating_id)
     lan = get_object_or_404(LAN, id=seating.lan.id)

--- a/apps/team/admin.py
+++ b/apps/team/admin.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin
+from django.contrib.admin.options import ModelAdmin
 
 from apps.team.models import Invitation, Team
 
 
+class InvitationAdmin(ModelAdmin):
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(Team)
-admin.site.register(Invitation)
+admin.site.register(Invitation, InvitationAdmin)

--- a/apps/userprofile/views.py
+++ b/apps/userprofile/views.py
@@ -26,7 +26,7 @@ def my_profile(request):
     breadcrumbs = (
         (settings.SITE_NAME, '/'),
         (_(u'Profile'), reverse('my_profile')),
-        (request.user.get_full_name(), ''),
+        (request.user.username, ''),
     )
 
     return render(request, 'user/profile.html', {'quser': request.user, 'profile': profile, 'breadcrumbs': breadcrumbs})

--- a/templates/competition/competition.html
+++ b/templates/competition/competition.html
@@ -164,9 +164,9 @@
                             {% for user in users %}
                                 <tr onclick="document.location='{% url 'public_profile' user %}';">
                                     {% if request.user == user %}
-                                        <td class="participant-you underline" title="{{ user.get_full_name }}">{{ user }}</td>
+                                        <td class="participant-you underline">{{ user }}</td>
                                     {% else %}
-                                        <td class="underline" title="{{ user.get_full_name }}">{{ user }}</td>
+                                        <td class="underline">{{ user }}</td>
                                     {% endif %}
                                 </tr>   
                             {% endfor %}

--- a/templates/lottery/drawing.html
+++ b/templates/lottery/drawing.html
@@ -17,7 +17,7 @@
     <div class="row">
         <div class="col-md-9">
             <h3>Winner:</h3>
-            <p>{{ winner.user.username }} ({{ winner.user.get_full_name }})</p>
+            <p><a href="{% url 'public_profile' winner %}">{{ winner.user.username }}</a></p>
         </div>
     </div>
     {% endif %}
@@ -25,13 +25,11 @@
     <div class="row">
         <div class="col-md-9">
             <h2>Winners</h2>
-            <table class="table table-bordered table-striped">
-                <thead><th>Username</th><th>Name</th>
+            <table class="table table-bordered table-striped table-hover click-table">
                 <tbody>
                     {% for winner in lottery.lotterywinner_set.all reversed %}
-                        <tr>
+                        <tr onclick="document.location='{% url 'public_profile' winner %}';">
                             <td>{{ winner.user.username }}</td>
-                            <td>{{ winner.user.get_full_name }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -7,7 +7,7 @@
             <li class="sidebar-header">
                 <a href="{% url 'my_profile' %}">{% trans "User Info" %}</a>
             </li>
-            <li><strong>{% trans "User name" %}:</strong><br/>{{ user.username }}</li>
+            <li><strong>{% trans "User" %}:</strong><br/>{{ user.username }}</li>
             <li><strong>{% trans "Name" %}:</strong><br/>{{ user.first_name }} {{ user.last_name }}</li>
             <li><strong>{% trans "Email" %}:</strong><br/>{{ user.email }}</li>
         {% endif %}

--- a/templates/team/team.html
+++ b/templates/team/team.html
@@ -23,13 +23,11 @@
                 <table class="table table-bordered table-striped table-hover click-table    ">
                     <thead>
                         <th class="col-md-4">{% trans "User name" %}</th>
-                        <th class="col-md-6">{% trans "Full name" %}</th>
                         <th class="col-md-2">{% trans "Options" %}</th>
                     </thead>
                     <tbody>
                         <tr>
                                 <td class="underline" onclick="document.location='{% url 'public_profile' team.leader %}';">{{ team.leader }}<div class="pull-right btn btn-xs btn-info btn-disabeled">Admin</div></td>
-                                <td class="underline" onclick="document.location='{% url 'public_profile' team.leader %}';">{{ team.leader.get_full_name }}</td>
                                 <td>{% if team.is_mine %}
                                         <div class="btn btn-xs btn-danger" onclick="disband()">
                                             <i class="icon-remove icon-white"></i> Disband Team
@@ -41,7 +39,6 @@
                         {% for member in team.members.all %}
                             <tr onclick="document.location='{% url 'public_profile' member %}';">
                                 <td class="underline">{{ member }}</td>
-                                <td class="underline">{{ member.get_full_name }}</td>
                                 <td>
                                 {% if user == team.leader %}
                                     <a class="btn btn-danger btn-xs" href="{% url 'remove_member' team.id member.id %}">{% trans "Remove" %}</a>
@@ -95,14 +92,12 @@
                 <table class="table table-bordered table-striped table-hover click-table    ">
                     <thead>
                         <th class="col-md-4">{% trans "User name" %}</th>
-                        <th class="col-md-6">{% trans "Full name" %}</th>
                         <th class="col-md-2">{% trans "Options" %}</th>
                     </thead>
                     <tbody>
                         {% for invite in invitations %}
                             <tr onclick="document.location='{% url 'public_profile' invite.invitee %}';">
                                 <td class="underline">{{ invite.invitee }}</td>
-                                <td class="underline">{{ invite.invitee.get_full_name }}</td>
                                 <td>
                                 {% if user == team.leader %}
                                     <a class="btn btn-danger btn-xs" href="{% url 'remove_invitation' team.id invite.token %}">{% trans "Remove" %}</a>

--- a/templates/team/team.html
+++ b/templates/team/team.html
@@ -68,13 +68,9 @@
                     <fieldset>
                         <legend>{% trans "Invite member" %}</legend>
                         <div class="form-group">
-                            <label class="col-md-1 control-label" for="selectMember">{% trans "Select" %}</label>
+                            <label class="col-md-1 control-label" for="selectMember">{% trans "Username" %}</label>
                             <div class="col-md-4">
-                                <select class="form-control" id="selectMember" name="selectMember">
-                                    {% for user in users %}
-                                        <option value="{{ user.id }}">{{ user }}</option>
-                                    {% endfor %}
-                                </select>
+                                <input type="text" class="form-control" id="selectMember" name="selectMember" required />
                             </div>
                             <div class="col-md-3 center-on-collapse form-actions-collapsed">
                                 <input type="submit" class="btn btn-primary" value="{% trans "Invite member" %}" />


### PR DESCRIPTION
### Status

- [X] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description
Make it possible to have a user on the site without publicly sharing your full name (one way or another). It also fixes broken auth for the seating list and map PDFs. And the drop-down list with all users in the team invite section has been replaced by a text field, to avoid leaking all usernames.

### Checklist

- [X] The code is linted
- [ ] My changes requires change to the documentation.
- [X] I have updated the documentation.
- [ ] I have introduced changes to build configuration.


### Minor Changes

- Hide full names of user where they aren't needed.
- Fix broken auth for seating list and map.
- Replace the drop-down with all users in the team invite section with a text field.
