### PR TITLE
Move SonarCloud addon into relevant job in Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ language: python
 python:
   - "2.7"
 
-addons:
-  sonarcloud:
-    organization: $SONARCLOUD_ORG
-    token: $SONARCLOUD_TOKEN
-
 services:
   - docker
 
@@ -52,6 +47,10 @@ jobs:
     - stage: test
       name: Analyze source code (SonarCloud)
       language: java
+      addons:
+        sonarcloud:
+          organization: $SONARCLOUD_ORG
+          token: $SONARCLOUD_TOKEN
       git:
         depth: false
       script: sonar-scanner


### PR DESCRIPTION
### Status

- [X] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description
Move SonarCloud addon into relevant job in Travis file. Prevents it from being initialized in all jobs.

### Checklist

- [X] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [X] I have introduced changes to build configuration.


### Minor Changes

- Move SonarCloud addon into relevant job in Travis file.