### PR TITLE
Fix sidebar sponsors

### DIFF
--- a/apps/sponsor/templatetags/sponsor_tags.py
+++ b/apps/sponsor/templatetags/sponsor_tags.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+from django import template
+
+from apps.lan.models import LAN
+from apps.sponsor.models import SponsorRelation
+
+
+register = template.Library()
+
+
+@register.inclusion_tag('sponsor/sponsor_list.html')
+def show_sponsor_list():
+
+    lans = LAN.objects.filter(end_date__gte=datetime.now())
+    if lans:
+        sponsor_relations = SponsorRelation.objects.filter(lan__in=lans)
+    else:
+        sponsor_relations = []
+
+    sponsors = [sponsor_relation.sponsor for sponsor_relation in sponsor_relations]
+
+    return {'sponsors': sponsors}

--- a/templates/sponsor/sponsor_list.html
+++ b/templates/sponsor/sponsor_list.html
@@ -1,0 +1,3 @@
+{% for sponsor in sponsors %}
+    <li><a href="{{ sponsor.website }}" target="_blank">{{ sponsor }}</a></li>
+{% endfor %}


### PR DESCRIPTION
### Status

- [x] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description
Readds sponsor files used by the sidebar, which were accidentally deleted after the last release. For some reason, attempting to load the missing tag library didn't cause an error when running the app in Docker, and caused the entire sidebar to not be rendered instead. It caused errors in virtuelenv in Windows, however.

No files were changed, only readded exactly as they were before deletion.

### Checklist

- [x] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [ ] I have introduced changes to build configuration.