### PR TITLE
Add Stripe payment descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-<<<<<<< HEAD
 - Added confirm dialogs for arrival toggle buttons.
 - Added filters on arrivals page for paid and arrived statuses.
 - Added more info to compo page info tables and compo list.
 - Added permission for showing team invites, regardless of membership status.
 - Added config option to show version and default to hidden.
+- Added Stripe payment descriptions for tickets.
 
 ### Changed
 - Made tickets for a LAN always visible.

--- a/apps/lan/models.py
+++ b/apps/lan/models.py
@@ -109,10 +109,9 @@ class Attendee(models.Model):
 
 
 class TicketType(TranslatableModel):
-    lan = models.ForeignKey(LAN, verbose_name=_(u'LAN'))
-
     # Note: "seats" in this context means "tickets" or "spots", not actual seats.
 
+    lan = models.ForeignKey(LAN, verbose_name=_(u'LAN'))
     price = models.IntegerField(_(u'price'), default=50)
     priority = models.IntegerField(_(u'prioity'), default=0, help_text=_(u'In what priority the tickets will show, higher number will show first.'))
     available_from = models.DateTimeField(_(u'release date'), default=datetime.now, help_text=_(u'When the tickets will be made available.'))

--- a/apps/payment/views.py
+++ b/apps/payment/views.py
@@ -78,6 +78,7 @@ def payment(request, ticket_type_id):
             })
 
     if request.method == 'POST':
+        description = u'{lan} {ticket} ticket for {user}'.format(ticket=ticket_type, lan=ticket_type.lan, user=request.user)
         json_data = json.loads(request.body)
         intent = None
         try:
@@ -87,6 +88,7 @@ def payment(request, ticket_type_id):
                     payment_method=str(json_data['payment_method_id']),
                     amount=ticket_type.price * 100,
                     currency='nok',
+                    description=description,
                     confirmation_method='manual',
                     confirm=True,
                 )


### PR DESCRIPTION
### Status

- [x] Done
- [ ] Work in progress
- [x] Needs testing from others

### Description
Adds Stripe payment descriptions for ticket purchases, so that Stripe payments can be correlated to LANs, users and tickets.

For instance, when user "batman" buys a "Standard" ticket for "LAN X", the description "LAN X Standard ticket for batman" appears in Stripe.