### PR TITLE
Make SonarCloud analysis automatic

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,3 @@
-sonar.projectKey=CasualGaming_studlan
 sonar.sourceEncoding=UTF-8
 sonar.sources=studlan,apps,requirements,templates,files
 sonar.tests=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,10 @@
 # - DOCKER_REPO
 # - DOCKER_USER (secure)
 # - DOCKER_PASSWORD (secure)
-# - SONARCLOUD_TOKEN (secure)
-# - SONARCLOUD_ORG
 # - SSH_HOST
 # - SSH_USER
 # - (automatic encryption keys) (secure)
 
-# virtualenv is implicit for python
 language: python
 python:
   - "2.7"
@@ -42,18 +39,6 @@ jobs:
       name: Lint
       install: pip install --upgrade -r requirements/test.txt
       script: flake8
-      # This does not fail the build if the SonarCloud quality gate fails,
-      # but SonarCloud has a GitHub PR status check which can be made required.
-    - stage: test
-      name: SonarCloud
-      language: java
-      addons:
-        sonarcloud:
-          organization: $SONARCLOUD_ORG
-          token: $SONARCLOUD_TOKEN
-      git:
-        depth: false
-      script: sonar-scanner
     - stage: test
       name: Validate Docker image
       install: true # NOP


### PR DESCRIPTION
### Status

- [x] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description

Replace the manual SonarCloud/SonarQube CI job with [SonarCloud automatic analyses](https://sonarcloud.io/documentation/automatic-analysis/). The CI job doesn't work with external PRs since our SonarCloud keys aren't exposed to external PRs. The presence of `.sonarcloud.properties` will automatically trigger SonarCloud.